### PR TITLE
feat: Update instructions to post Analysis Release v25.2.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This repository intentionally produces a `nanobind` module and not an Python lib
 
 ## Requirements
 
-* Any CVMFS enabled machine or an ATLAS analysis release Linux container (e.g. `gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.27`)
+* Any CVMFS enabled machine or an ATLAS analysis release `v25.2.30+` Linux container (e.g. `gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.30`)
+   - `nanobind` was added to the ATLAS analysis release externals in release `25.2.30`. (c.f. [Athena MR 74980](https://gitlab.cern.ch/atlas/athena/-/merge_requests/74980))
 
 ## Getting started
 

--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,7 @@ else
     echo -e "\n# lsetup git\n"
     lsetup git
 
+    # Just need to be post Analysis release v25.2.30
     echo -e "\n# asetup AnalysisBase,main,latest\n"
     asetup AnalysisBase,main,latest
 fi
@@ -30,7 +31,7 @@ if [[ ! -d .venv ]]; then
     # Ensure user controlled virtual environment
     cvmfs-venv .venv
     . .venv/bin/activate
-    uv pip install --upgrade nanobind pytest
+    uv pip install --upgrade pytest
     deactivate
 fi
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-nanobind


### PR DESCRIPTION
* Analysis Release v25.2.30 is the release that starts to indlcude nanobind in the ATLAS Externals.
   - c.f. https://gitlab.cern.ch/atlas/athena/-/merge_requests/74980