### PR TITLE
chore: Have build_normal_cmake.sh work inside repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ git clone git@github.com:matthewfeickert/atlas-cmake-nanobind-example.git && cd 
 To run the "normal" CMake example with `nanobind` run
 
 ```
-bash build.sh
+bash build_normal_cmake.sh
 ```
 
 and to run the ATLAS CMake example run

--- a/build_normal_cmake.sh
+++ b/build_normal_cmake.sh
@@ -43,9 +43,9 @@ if [[ -d build_normal_cmake ]]; then
     rm -rf build_normal_cmake
 fi
 
-echo -e "\n# cmake -S atlas-cmake-nanobind-example/normal_cmake -B build_normal_cmake\n"
+echo -e "\n# cmake -S normal_cmake -B build_normal_cmake\n"
 cmake \
-    -S atlas-cmake-nanobind-example/normal_cmake \
+    -S normal_cmake \
     -B build_normal_cmake
 
 echo -e "\n# cmake build_normal_cmake -LH\n"


### PR DESCRIPTION
* Rename 'build.sh' to 'build_normal_cmake.sh'.
* Have build script work inside of repository.