### PR TITLE
feat: Add simpler nlohmann/json example

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "normal_nlohmann/json"]
+	path = normal_nlohmann/json
+	url = https://github.com/nlohmann/json.git

--- a/README.md
+++ b/README.md
@@ -30,3 +30,17 @@ and to run the ATLAS CMake example run
 ```
 bash build_atlas_cmake.sh
 ```
+
+## Other examples
+
+To verify a simper example first for ATLAS CMake, first run
+
+```
+bash run_docker.sh
+```
+
+(or be already in an ATLAS Analysis Release environment) and then run
+
+```
+build_normal_nlohmann.sh
+```

--- a/build_normal_nlohmann.sh
+++ b/build_normal_nlohmann.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Setup release
+if [[ -f /release_setup.sh ]]; then
+    echo -e "\n# Assuming inside a Linux container"
+    echo -e "\n# . /release_setup.sh\n"
+    . /release_setup.sh
+else
+    echo -e "\n# setupATLAS\n"
+    export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+    # Allows for working with wrappers as well
+    . "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh" --quiet || echo "~~~ERROR: setupATLAS failed!~~~"
+
+    echo -e "\n# lsetup git\n"
+    lsetup git
+
+    # Just need to be post Analysis release v25.2.30
+    echo -e "\n# asetup AnalysisBase,main,latest\n"
+    asetup AnalysisBase,main,latest
+fi
+
+if [[ -d build_normal_nlohmann ]]; then
+    echo -e "\n# rm -rf build_normal_nlohmann\n"
+    rm -rf build_normal_nlohmann
+fi
+
+echo -e "\n# cmake -S normal_nlohmann -B build_normal_nlohmann\n"
+cmake \
+    -DCMAKE_VERBOSE_MAKEFILE=ON \
+    -S normal_nlohmann \
+    -B build_normal_nlohmann
+
+echo -e "\n# cmake build_normal_nlohmann -LH\n"
+cmake build_normal_nlohmann -LH
+
+echo -e "\n# cmake --build build_normal_nlohmann --clean-first --parallel 8\n"
+# cmake \
+#     --build build_normal_nlohmann \
+#     --clean-first \
+#     --parallel $(nproc --ignore=1)
+cmake \
+    --build build_normal_nlohmann \
+    --clean-first \
+    --parallel 8
+
+echo -e "\n# ./build_normal_nlohmann/example\n"
+./build_normal_nlohmann/example

--- a/build_normal_nlohmann.sh
+++ b/build_normal_nlohmann.sh
@@ -19,6 +19,9 @@ else
     asetup AnalysisBase,main,latest
 fi
 
+echo -e "\n# git submodule update --init --recursive\n"
+git submodule update --init --recursive
+
 if [[ -d build_normal_nlohmann ]]; then
     echo -e "\n# rm -rf build_normal_nlohmann\n"
     rm -rf build_normal_nlohmann

--- a/normal_nlohmann/CMakeLists.txt
+++ b/normal_nlohmann/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15...3.30)
+project(nlohmann_json_example)
+
+find_package(nlohmann_json 3.2.0 REQUIRED)
+
+add_executable(example src/README.cpp)
+
+target_link_libraries(example PRIVATE nlohmann_json::nlohmann_json)

--- a/normal_nlohmann/src/README.cpp
+++ b/normal_nlohmann/src/README.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <iomanip>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+int main()
+{
+    // create a JSON object
+    json j =
+    {
+        {"pi", 3.141},
+        {"happy", true},
+        {"name", "Niels"},
+        {"nothing", nullptr},
+        {
+            "answer", {
+                {"everything", 42}
+            }
+        },
+        {"list", {1, 0, 2}},
+        {
+            "object", {
+                {"currency", "USD"},
+                {"value", 42.99}
+            }
+        }
+    };
+
+    // add new values
+    j["new"]["key"]["value"] = {"another", "list"};
+
+    // count elements
+    auto s = j.size();
+    j["size"] = s;
+
+    // pretty print with indent of 4 spaces
+    std::cout << std::setw(4) << j << '\n';
+}


### PR DESCRIPTION
```
* Add simple nlohmann/json executable example to provide a hopefully less complicated
  example of using ATLAS CMake to build external libraries.
   - c.f. https://github.com/nlohmann/json
```