### PR TITLE
feat: Add nlohmann/json ATLAS CMake example

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "normal_nlohmann/json"]
 	path = normal_nlohmann/json
 	url = https://github.com/nlohmann/json.git
+[submodule "atlas_cmake/nlohmann_example/json"]
+	path = atlas_cmake/nlohmann_example/json
+	url = https://github.com/nlohmann/json.git

--- a/atlas_cmake/nlohmann_example/CMakeLists.txt
+++ b/atlas_cmake/nlohmann_example/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15...3.30)
+atlas_subdir(nlohmann_json_example)
+
+find_package(nlohmann_json 3.2.0 REQUIRED)
+
+atlas_add_executable(example src/README.cpp)
+
+target_link_libraries(example PRIVATE nlohmann_json::nlohmann_json)

--- a/atlas_cmake/nlohmann_example/CMakeLists.txt
+++ b/atlas_cmake/nlohmann_example/CMakeLists.txt
@@ -3,6 +3,6 @@ atlas_subdir(nlohmann_json_example)
 
 find_package(nlohmann_json 3.2.0 REQUIRED)
 
-atlas_add_executable(example src/README.cpp)
+add_executable(example src/README.cpp)
 
 target_link_libraries(example PRIVATE nlohmann_json::nlohmann_json)

--- a/atlas_cmake/nlohmann_example/CMakeLists.txt
+++ b/atlas_cmake/nlohmann_example/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.15...3.30)
-atlas_subdir(nlohmann_json_example)
+# Note that in normal CMake this would be the `project` command and it could
+# be anything, e.g. project(nlohmann_json_example).
+# But in ATLAS CMake, it is a subdir command and so the "project name" must
+# be an actual directory name.
+atlas_subdir(nlohmann_example)
 
 find_package(nlohmann_json 3.2.0 REQUIRED)
 

--- a/atlas_cmake/nlohmann_example/src/README.cpp
+++ b/atlas_cmake/nlohmann_example/src/README.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <iomanip>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+int main()
+{
+    // create a JSON object
+    json j =
+    {
+        {"pi", 3.141},
+        {"happy", true},
+        {"name", "Niels"},
+        {"nothing", nullptr},
+        {
+            "answer", {
+                {"everything", 42}
+            }
+        },
+        {"list", {1, 0, 2}},
+        {
+            "object", {
+                {"currency", "USD"},
+                {"value", 42.99}
+            }
+        }
+    };
+
+    // add new values
+    j["new"]["key"]["value"] = {"another", "list"};
+
+    // count elements
+    auto s = j.size();
+    j["size"] = s;
+
+    // pretty print with indent of 4 spaces
+    std::cout << std::setw(4) << j << '\n';
+}

--- a/atlas_cmake/package_filters.txt
+++ b/atlas_cmake/package_filters.txt
@@ -1,4 +1,4 @@
-# + simple_project
++ simple_project
 + nlohmann_example
 #
 - .*

--- a/atlas_cmake/package_filters.txt
+++ b/atlas_cmake/package_filters.txt
@@ -1,4 +1,6 @@
+# simple_project normal C++ but setup to work with an ATLAS Analysis Release layout
 + simple_project
+# nlohmann_example is an example project that involves an external Git submodule
 + nlohmann_example
 #
 - .*

--- a/atlas_cmake/package_filters.txt
+++ b/atlas_cmake/package_filters.txt
@@ -1,3 +1,4 @@
-+ simple_project
+# + simple_project
++ nlohmann_example
 #
 # - .*

--- a/atlas_cmake/package_filters.txt
+++ b/atlas_cmake/package_filters.txt
@@ -1,4 +1,4 @@
 # + simple_project
 + nlohmann_example
 #
-# - .*
+- .*

--- a/build_atlas_nlohmann.sh
+++ b/build_atlas_nlohmann.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Setup release
+if [[ -f /release_setup.sh ]]; then
+    echo -e "\n# Assuming inside a Linux container"
+    echo -e "\n# . /release_setup.sh\n"
+    . /release_setup.sh
+else
+    echo -e "\n# setupATLAS\n"
+    export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+    # Allows for working with wrappers as well
+    . "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh" --quiet || echo "~~~ERROR: setupATLAS failed!~~~"
+
+    echo -e "\n# lsetup git\n"
+    lsetup git
+
+    # Just need to be post Analysis release v25.2.30
+    echo -e "\n# asetup AnalysisBase,25.2.30\n"
+    asetup AnalysisBase,25.2.30
+fi
+
+if [[ -d build_atlas_nlohmann ]]; then
+    echo -e "\n# rm -rf build_atlas_nlohmann\n"
+    rm -rf build_atlas_nlohmann
+fi
+
+echo -e "\n# cmake -DATLAS_PACKAGE_FILTER_FILE=atlas_cmake/package_filters.txt -S atlas_cmake/Projects/WorkDir -B build_atlas_nlohmann\n"
+cmake \
+    -DATLAS_PACKAGE_FILTER_FILE=atlas_cmake/package_filters.txt \
+    -S atlas_cmake/Projects/WorkDir \
+    -B build_atlas_nlohmann
+
+echo -e "\n# cmake build_atlas_nlohmann -LH\n"
+cmake build_atlas_nlohmann -LH
+
+echo -e "\n# cmake --build build_atlas_nlohmann --clean-first --parallel 8\n"
+# cmake \
+#     --build build_atlas_nlohmann \
+#     --clean-first \
+#     --parallel $(nproc --ignore=1)
+cmake \
+    --build build_atlas_nlohmann \
+    --clean-first \
+    --parallel 8
+
+echo -e "\n# cd build_atlas_nlohmann\n"
+cd build_atlas_nlohmann
+
+echo -e "\n# Setup environment\n# . $(find . -type f -iname "setup.sh")\n"
+. $(find . -type f -iname "setup.sh")

--- a/build_atlas_nlohmann.sh
+++ b/build_atlas_nlohmann.sh
@@ -48,3 +48,6 @@ cd build_atlas_nlohmann
 
 echo -e "\n# Setup environment\n# . $(find . -type f -iname "setup.sh")\n"
 . $(find . -type f -iname "setup.sh")
+
+echo -e "\n# $(find . -type f -iname example)\n"
+$(find . -type f -iname example)


### PR DESCRIPTION
Resolves #9 

* Add example of building an project with ATLAS CMake that uses
  and external submodule (https://github.com/nlohmann/json).
   - Add submodule under project directory tree (atlas_cmake/nlohmann_example/json).
   - Use atlas_subdir() with a real directory name instead of project() with arbitrary name.
   - Add '- .*' in package_filters.txt to remove all other possible package targets.
* Add build_atlas_nlohmann.sh build script.