### PR TITLE
feat: Add CPython C API CMake build example

### DIFF
--- a/build_normal_cpython.sh
+++ b/build_normal_cpython.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Setup release
+if [[ -f /release_setup.sh ]]; then
+    echo -e "\n# Assuming inside a Linux container"
+    echo -e "\n# . /release_setup.sh\n"
+    . /release_setup.sh
+else
+    echo -e "\n# setupATLAS\n"
+    export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+    # Allows for working with wrappers as well
+    . "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh" --quiet || echo "~~~ERROR: setupATLAS failed!~~~"
+
+    echo -e "\n# lsetup git\n"
+    lsetup git
+
+    # Just need to be post Analysis release v25.2.30
+    echo -e "\n# asetup AnalysisBase,main,latest\n"
+    asetup AnalysisBase,main,latest
+fi
+
+if [[ -d build_normal_cpython ]]; then
+    echo -e "\n# rm -rf build_normal_cpython\n"
+    rm -rf build_normal_cpython
+fi
+
+echo -e "\n# cmake -S normal_cpython -B build_normal_cpython\n"
+cmake \
+    -DCMAKE_VERBOSE_MAKEFILE=ON \
+    -S normal_cpython \
+    -B build_normal_cpython
+
+echo -e "\n# cmake build_normal_cpython -LH\n"
+cmake build_normal_cpython -LH
+
+echo -e "\n# cmake --build build_normal_cpython --clean-first --parallel 8\n"
+# cmake \
+#     --build build_normal_cpython \
+#     --clean-first \
+#     --parallel $(nproc --ignore=1)
+cmake \
+    --build build_normal_cpython \
+    --clean-first \
+    --parallel 8
+
+echo -e "\n# ./build_normal_cpython/cpython_api_example\n"
+./build_normal_cpython/cpython_api_example

--- a/normal_cpython/CMakeLists.txt
+++ b/normal_cpython/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.16...3.31)
+project(cpython_api_cmake_example)
+
+find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
+
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+add_executable(cpython_api_example src/cpython_api_example.cpp)
+
+# Need to find Python.h
+target_include_directories(cpython_api_example PUBLIC "${Python_INCLUDE_DIRS}")
+# Need to find libpython3.MINOR.so to link against
+target_link_libraries(cpython_api_example PRIVATE "${Python_LIBRARIES}")

--- a/normal_cpython/src/cpython_api_example.cpp
+++ b/normal_cpython/src/cpython_api_example.cpp
@@ -1,0 +1,8 @@
+#include <Python.h>
+
+int main() {
+    Py_Initialize();
+    PyRun_SimpleString("print('Hello from Python!')");
+    Py_Finalize();
+    return 0;
+}


### PR DESCRIPTION
* Add example of building a trivial CPython C API program that relies on the `Development` components of Python to be found, and to be told about the location of the Python include directories (`Python_INCLUDE_DIRS`) and to link against `libpython3.MINOR.so` (`Python_LIBRARIES`).
* This doesn't use nanobind at all, but acts as an example of what is required when working with C++ and Python in general, which makes adapting nanobind into ATLAS CMake slightly easier to think about.