### PR TITLE
feat: Use CMake Python imported targets

### DIFF
--- a/atlas_cmake/nanobind_example/CMakeLists.txt
+++ b/atlas_cmake/nanobind_example/CMakeLists.txt
@@ -6,10 +6,20 @@ atlas_subdir(nanobind_example)
 if (CMAKE_VERSION VERSION_LESS 3.18)
   set(DEV_MODULE Development)
 else()
-  set(DEV_MODULE Development Development.Module)
+  # Development.Embed required for Python::Python imported target
+  set(DEV_MODULE Development Development.Module Development.Embed)
 endif()
 
 find_package(Python 3.8 COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)
+
+if (NOT TARGET Python::Python)
+  message(
+    FATAL_ERROR
+    "As component Development.Embed was not found"
+    " (Python_Development.Embed_FOUND=${Python_Development.Embed_FOUND}) the"
+    " required imported target Python::Python was not defined."
+    )
+endif()
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
@@ -59,15 +69,8 @@ nanobind_add_module(
 
 # Required if and only if using NB_SHARED
 if (NANOBIND_LIBRARY_LINK_TYPE STREQUAL "NB_SHARED")
-  target_link_libraries(
-    nanobind
-    PRIVATE
-  "${Python_LIBRARIES}"
-  )
+  # Imported target Python::Python defined if component Development.Embed is found
+  target_link_libraries(nanobind PRIVATE Python::Python)
 endif()
 
-target_link_libraries(
-  nanobind_example_ext
-  PRIVATE
-  "${Python_LIBRARIES}"
-)
+target_link_libraries(nanobind_example_ext PRIVATE Python::Python)

--- a/atlas_cmake/nanobind_example/CMakeLists.txt
+++ b/atlas_cmake/nanobind_example/CMakeLists.txt
@@ -2,12 +2,12 @@ cmake_minimum_required(VERSION 3.16...3.31)
 atlas_subdir(nanobind_example)
 
 # Though nanobind only needs Development.Module it seems ATLAS CMake requires
-# the full Development to be used.
+# the full Development (Development.Module and Development.Embed) to be used.
 if (CMAKE_VERSION VERSION_LESS 3.18)
   set(DEV_MODULE Development)
 else()
   # Development.Embed required for Python::Python imported target
-  set(DEV_MODULE Development Development.Module Development.Embed)
+  set(DEV_MODULE Development.Module Development.Embed)
 endif()
 
 find_package(Python 3.8 COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)

--- a/normal_cpython/CMakeLists.txt
+++ b/normal_cpython/CMakeLists.txt
@@ -1,7 +1,16 @@
 cmake_minimum_required(VERSION 3.16...3.31)
 project(cpython_api_cmake_example)
 
-find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
+find_package(Python 3.8 COMPONENTS Interpreter Development Development.Embed REQUIRED)
+
+if (NOT TARGET Python::Python)
+  message(
+    FATAL_ERROR
+    "As component Development.Embed was not found"
+    " (Python_Development.Embed_FOUND=${Python_Development.Embed_FOUND}) the"
+    " required imported target Python::Python was not defined."
+    )
+endif()
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
@@ -12,5 +21,5 @@ add_executable(cpython_api_example src/cpython_api_example.cpp)
 
 # Need to find Python.h
 target_include_directories(cpython_api_example PUBLIC "${Python_INCLUDE_DIRS}")
-# Need to find libpython3.MINOR.so to link against
-target_link_libraries(cpython_api_example PRIVATE "${Python_LIBRARIES}")
+# Imported target Python::Python defined if component Development.Embed is found
+target_link_libraries(cpython_api_example PRIVATE Python::Python)

--- a/normal_cpython/CMakeLists.txt
+++ b/normal_cpython/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16...3.31)
 project(cpython_api_cmake_example)
 
-find_package(Python 3.8 COMPONENTS Interpreter Development Development.Embed REQUIRED)
+find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
 
 if (NOT TARGET Python::Python)
   message(


### PR DESCRIPTION
Resolves #13 

* Leverage the CMake Python imported target `Python::Python`.
   - Python::Python allows for linking against the Python interpreter's library (the correct version of `libpython`) and is defined if component Development.Embed is found.
   - Note that the required use of Development.Embed for working with nanobind in ATLAS CMake is peculiar and a constraint of ATLAS CMake.
   - c.f. https://cmake.org/cmake/help/latest/module/FindPython.html#imported-targets
* Add CMake `FATAL_ERROR` message when `Python::Python` target is not found.