### PR TITLE
feat: Add simple example of class bindings

### DIFF
--- a/atlas_cmake/nanobind_example/src/nanobind_example_ext.cpp
+++ b/atlas_cmake/nanobind_example/src/nanobind_example_ext.cpp
@@ -1,10 +1,44 @@
 #include <nanobind/nanobind.h>
+#include <nanobind/operators.h>
 
 namespace nb = nanobind;
 
 using namespace nb::literals;
 
+// c.f. https://nanobind.readthedocs.io/en/latest/classes.html
+class Vector2 {
+public:
+    Vector2(float x, float y) : x(x), y(y) { }
+
+    Vector2 operator+(const Vector2 &v) const { return Vector2(x + v.x, y + v.y); }
+    Vector2 operator*(float value) const { return Vector2(x * value, y * value); }
+    Vector2 operator-() const { return Vector2(-x, -y); }
+    Vector2& operator+=(const Vector2 &v) { x += v.x; y += v.y; return *this; }
+    Vector2& operator*=(float v) { x *= v; y *= v; return *this; }
+
+    friend Vector2 operator*(float f, const Vector2 &v) {
+        return Vector2(f * v.x, f * v.y);
+    }
+
+    std::string to_string() const {
+        return "[" + std::to_string(x) + ", " + std::to_string(y) + "]";
+    }
+private:
+    float x, y;
+};
+
 NB_MODULE(nanobind_example_ext, module) {
     module.doc() = "This is a \"hello world\" example with nanobind";
     module.def("add", [](int a, int b) { return a + b; }, "a"_a, "b"_a);
+
+    // There might be a better way to handle the __repr__
+    nb::class_<Vector2>(module, "Vector2")
+        .def(nb::init<float, float>())
+        .def(nb::self + nb::self)
+        .def(nb::self += nb::self)
+        .def(nb::self *= float())
+        .def(float() * nb::self)
+        .def(nb::self * float())
+        .def(-nb::self)
+        .def("__repr__", [](const Vector2 &v) { return nb::str(v.to_string().c_str()); });
 }

--- a/build_atlas_cmake.sh
+++ b/build_atlas_cmake.sh
@@ -63,3 +63,6 @@ python -c 'import nanobind_example_ext; print(nanobind_example_ext.add(1, 2))'
 
 echo -e "\n# python -c 'import nanobind_example_ext; print(nanobind_example_ext.add(a=1, b=2))'\n"
 python -c 'import nanobind_example_ext; print(nanobind_example_ext.add(a=1, b=2))'
+
+echo -e "\n# python -c 'from nanobind_example_ext import Vector2; v1 = Vector2(1, 2.); v2 = Vector2(3., 4.); print(f"v1={v1}"); print(f"v2={v2}"); print(f"v1 + v2={v1 + v2}")'\n"
+python -c 'from nanobind_example_ext import Vector2; v1 = Vector2(1, 2.); v2 = Vector2(3., 4.); print(f"v1={v1}"); print(f"v2={v2}"); print(f"v1 + v2={v1 + v2}")'

--- a/build_normal_cmake.sh
+++ b/build_normal_cmake.sh
@@ -70,3 +70,6 @@ python -c 'import nanobind_example_ext; print(nanobind_example_ext.add(1, 2))'
 
 echo -e "\n# python -c 'import nanobind_example_ext; print(nanobind_example_ext.add(a=1, b=2))'\n"
 python -c 'import nanobind_example_ext; print(nanobind_example_ext.add(a=1, b=2))'
+
+echo -e "\n# python -c 'from nanobind_example_ext import Vector2; v1 = Vector2(1, 2.); v2 = Vector2(3., 4.); print(f"v1={v1}"); print(f"v2={v2}"); print(f"v1 + v2={v1 + v2}")'\n"
+python -c 'from nanobind_example_ext import Vector2; v1 = Vector2(1, 2.); v2 = Vector2(3., 4.); print(f"v1={v1}"); print(f"v2={v2}"); print(f"v1 + v2={v1 + v2}")'

--- a/normal_cmake/src/nanobind_example_ext.cpp
+++ b/normal_cmake/src/nanobind_example_ext.cpp
@@ -1,10 +1,44 @@
 #include <nanobind/nanobind.h>
+#include <nanobind/operators.h>
 
 namespace nb = nanobind;
 
 using namespace nb::literals;
 
+// c.f. https://nanobind.readthedocs.io/en/latest/classes.html
+class Vector2 {
+public:
+    Vector2(float x, float y) : x(x), y(y) { }
+
+    Vector2 operator+(const Vector2 &v) const { return Vector2(x + v.x, y + v.y); }
+    Vector2 operator*(float value) const { return Vector2(x * value, y * value); }
+    Vector2 operator-() const { return Vector2(-x, -y); }
+    Vector2& operator+=(const Vector2 &v) { x += v.x; y += v.y; return *this; }
+    Vector2& operator*=(float v) { x *= v; y *= v; return *this; }
+
+    friend Vector2 operator*(float f, const Vector2 &v) {
+        return Vector2(f * v.x, f * v.y);
+    }
+
+    std::string to_string() const {
+        return "[" + std::to_string(x) + ", " + std::to_string(y) + "]";
+    }
+private:
+    float x, y;
+};
+
 NB_MODULE(nanobind_example_ext, module) {
     module.doc() = "This is a \"hello world\" example with nanobind";
     module.def("add", [](int a, int b) { return a + b; }, "a"_a, "b"_a);
+
+    // There might be a better way to handle the __repr__
+    nb::class_<Vector2>(module, "Vector2")
+        .def(nb::init<float, float>())
+        .def(nb::self + nb::self)
+        .def(nb::self += nb::self)
+        .def(nb::self *= float())
+        .def(float() * nb::self)
+        .def(nb::self * float())
+        .def(-nb::self)
+        .def("__repr__", [](const Vector2 &v) { return nb::str(v.to_string().c_str()); });
 }


### PR DESCRIPTION
Addresses part of Issue #14. There might be additional difficulties, so leaving that Issue open for the time being.

* Add simple Vector2 class following the example in the docs.
   - c.f. https://nanobind.readthedocs.io/en/latest/classes.html