### PR TITLE
fix: Properly escape quotes in build scripts

### DIFF
--- a/build_atlas_cmake.sh
+++ b/build_atlas_cmake.sh
@@ -64,5 +64,5 @@ python -c 'import nanobind_example_ext; print(nanobind_example_ext.add(1, 2))'
 echo -e "\n# python -c 'import nanobind_example_ext; print(nanobind_example_ext.add(a=1, b=2))'\n"
 python -c 'import nanobind_example_ext; print(nanobind_example_ext.add(a=1, b=2))'
 
-echo -e "\n# python -c 'from nanobind_example_ext import Vector2; v1 = Vector2(1, 2.); v2 = Vector2(3., 4.); print(f"v1={v1}"); print(f"v2={v2}"); print(f"v1 + v2={v1 + v2}")'\n"
+echo -e "\n# python -c 'from nanobind_example_ext import Vector2; v1 = Vector2(1, 2.); v2 = Vector2(3., 4.); print(f\"v1={v1}\"); print(f\"v2={v2}\"); print(f\"v1 + v2={v1 + v2}\")'\n"
 python -c 'from nanobind_example_ext import Vector2; v1 = Vector2(1, 2.); v2 = Vector2(3., 4.); print(f"v1={v1}"); print(f"v2={v2}"); print(f"v1 + v2={v1 + v2}")'

--- a/build_normal_cmake.sh
+++ b/build_normal_cmake.sh
@@ -71,5 +71,5 @@ python -c 'import nanobind_example_ext; print(nanobind_example_ext.add(1, 2))'
 echo -e "\n# python -c 'import nanobind_example_ext; print(nanobind_example_ext.add(a=1, b=2))'\n"
 python -c 'import nanobind_example_ext; print(nanobind_example_ext.add(a=1, b=2))'
 
-echo -e "\n# python -c 'from nanobind_example_ext import Vector2; v1 = Vector2(1, 2.); v2 = Vector2(3., 4.); print(f"v1={v1}"); print(f"v2={v2}"); print(f"v1 + v2={v1 + v2}")'\n"
+echo -e "\n# python -c 'from nanobind_example_ext import Vector2; v1 = Vector2(1, 2.); v2 = Vector2(3., 4.); print(f\"v1={v1}\"); print(f\"v2={v2}\"); print(f\"v1 + v2={v1 + v2}\")'\n"
 python -c 'from nanobind_example_ext import Vector2; v1 = Vector2(1, 2.); v2 = Vector2(3., 4.); print(f"v1={v1}"); print(f"v2={v2}"); print(f"v1 + v2={v1 + v2}")'


### PR DESCRIPTION
* Escpae '"' correctly so that f-strings work if the printed command is copied and pasted.