### PR TITLE
chore: Remove unreachable FATAL_ERROR messages

### DIFF
--- a/atlas_cmake/nanobind_example/CMakeLists.txt
+++ b/atlas_cmake/nanobind_example/CMakeLists.txt
@@ -12,15 +12,6 @@ endif()
 
 find_package(Python 3.8 COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)
 
-if (NOT TARGET Python::Python)
-  message(
-    FATAL_ERROR
-    "As component Development.Embed was not found"
-    " (Python_Development.Embed_FOUND=${Python_Development.Embed_FOUND}) the"
-    " required imported target Python::Python was not defined."
-    )
-endif()
-
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")

--- a/normal_cpython/CMakeLists.txt
+++ b/normal_cpython/CMakeLists.txt
@@ -3,15 +3,6 @@ project(cpython_api_cmake_example)
 
 find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
 
-if (NOT TARGET Python::Python)
-  message(
-    FATAL_ERROR
-    "As component Development.Embed was not found"
-    " (Python_Development.Embed_FOUND=${Python_Development.Embed_FOUND}) the"
-    " required imported target Python::Python was not defined."
-    )
-endif()
-
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")


### PR DESCRIPTION
Resolves #18 

* As `find_package(Python 3.8 COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)` is used, if the components requested are not found there will be a failure given the `REQUIRED`. So a `FATAL_ERROR` message related to a target of a missing component would be unreachable.